### PR TITLE
Integrate the module caching mod

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier": "^2.0.5",
     "readdir-glob": "^1.1.1",
     "typescript": "~4.8.4",
-    "ultimate-crosscode-typedefs": "github:dmitmel/ultimate-crosscode-typedefs"
+    "ultimate-crosscode-typedefs": "github:CCDirectLink/ultimate-crosscode-typedefs"
   },
   "scripts": {
     "build": "tsc --build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   jszip:
     specifier: '=3.10.1'
@@ -52,8 +56,8 @@ devDependencies:
     specifier: ~4.8.4
     version: 4.8.4
   ultimate-crosscode-typedefs:
-    specifier: github:dmitmel/ultimate-crosscode-typedefs
-    version: github.com/dmitmel/ultimate-crosscode-typedefs/160a1d3e63c76c5caa2601095c3061b89aade569
+    specifier: github:CCDirectLink/ultimate-crosscode-typedefs
+    version: github.com/CCDirectLink/ultimate-crosscode-typedefs/9a0fd3ea3c6ea57822fbbedff0cee078b768a069
 
 packages:
 
@@ -1571,6 +1575,17 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
+  github.com/CCDirectLink/ultimate-crosscode-typedefs/9a0fd3ea3c6ea57822fbbedff0cee078b768a069:
+    resolution: {tarball: https://codeload.github.com/CCDirectLink/ultimate-crosscode-typedefs/tar.gz/9a0fd3ea3c6ea57822fbbedff0cee078b768a069}
+    name: ultimate-crosscode-typedefs
+    version: 0.0.1
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@types/jquery': 1.10.31
+      '@types/node': 18.15.3
+      '@types/semver': 6.2.3
+    dev: true
+
   github.com/dmitmel/eslint-config-dmitmel/690f1b1121d342fcc8ee511ca9f2af7502f53db6(eslint@8.36.0):
     resolution: {tarball: https://codeload.github.com/dmitmel/eslint-config-dmitmel/tar.gz/690f1b1121d342fcc8ee511ca9f2af7502f53db6}
     id: github.com/dmitmel/eslint-config-dmitmel/690f1b1121d342fcc8ee511ca9f2af7502f53db6
@@ -1581,15 +1596,4 @@ packages:
       eslint: '>=8.17.0'
     dependencies:
       eslint: 8.36.0
-    dev: true
-
-  github.com/dmitmel/ultimate-crosscode-typedefs/160a1d3e63c76c5caa2601095c3061b89aade569:
-    resolution: {tarball: https://codeload.github.com/dmitmel/ultimate-crosscode-typedefs/tar.gz/160a1d3e63c76c5caa2601095c3061b89aade569}
-    name: ultimate-crosscode-typedefs
-    version: 0.0.1
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@types/jquery': 1.10.31
-      '@types/node': 18.15.3
-      '@types/semver': 6.2.3
     dev: true

--- a/runtime/src/_main.ts
+++ b/runtime/src/_main.ts
@@ -8,6 +8,7 @@ import { namespace as patchList } from './patch-list.js';
 import { namespace as impactInitHooks } from './impact-init-hooks.js';
 import { namespace as impactModuleHooks } from './impact-module-hooks.js';
 import { namespace as resources } from './resources.js';
+import { namespace as moduleCache } from './module-cache.js';
 
 import './error-screen.js';
 import './resources-injections.js';
@@ -28,6 +29,7 @@ export default class RuntimeModMainClass implements modloader.Mod.PluginClass {
       patchList,
       impactInitHooks,
       impactModuleHooks,
+      moduleCache,
       resources,
     });
   }

--- a/runtime/src/_main.ts
+++ b/runtime/src/_main.ts
@@ -35,6 +35,9 @@ export default class RuntimeModMainClass implements modloader.Mod.PluginClass {
   }
 
   public onImpactInit(): void {
+    for (let [_, mod] of modloader.loadedMods)
+      if (mod.manifest.modPrefix)
+        moduleCache.registerModPrefix(mod.manifest.modPrefix, mod.baseDirectory.substring(7));
     for (let cb of impactInitHooks.callbacks) cb();
   }
 

--- a/runtime/src/module-cache.ts
+++ b/runtime/src/module-cache.ts
@@ -1,0 +1,38 @@
+import * as impactInitHooks from './impact-init-hooks.js';
+// TODO: PR to UCCTD
+declare global {
+  namespace ccmod.moduleCache {
+    const prefixes: Map<string, string>;
+    function registerModPrefix(prefix: string, path: string): void;
+  }
+}
+
+let oldLoadScript: typeof ig._loadScript | undefined;
+export const prefixes = new Map<string, string>();
+function registerModPrefix(prefix: string, path: string): void {
+  prefixes.set(prefix, path);
+}
+
+impactInitHooks.add(() => {
+  oldLoadScript = ig._loadScript;
+  function _loadScript(moduleName: string, requirer?: string | null): void {
+    if (moduleName.includes('.')) {
+      const root = moduleName.split('.')[0];
+      let path = prefixes.get(root);
+      if (path) {
+        ig.lib = path;
+      }
+    }
+
+    oldLoadScript!(moduleName, requirer);
+
+    ig.lib = '';
+  }
+
+  ig._loadScript = _loadScript;
+});
+
+export const namespace: typeof ccmod.moduleCache = {
+  prefixes,
+  registerModPrefix,
+};

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -103,6 +103,7 @@ export class Validator {
 
       this.assertAssets(['assets'], data.assets);
       this.assertType(['assetsDir'], data.assetsDir, [Type.string], true);
+      this.assertType(['modPrefix'], data.modPrefix, [Type.string], true);
 
       this.assertType(['plugin'], data.plugin, [Type.string], true);
       this.assertType(['preload'], data.preload, [Type.string], true);


### PR DESCRIPTION
Adds a new manifest key, `modPrefix`, which allows you to register an Impact module root for your mod.
